### PR TITLE
CI/CD #37: Use volume instead of binding/mounting

### DIFF
--- a/compose/alpha/docker-compose.yml
+++ b/compose/alpha/docker-compose.yml
@@ -3,7 +3,9 @@ services:
     image: augustodelg/pocketbase:latest
     restart: unless-stopped
     volumes:
-      - ./pocketbase-data:/pb_data
+      # Cant use directory binding since Linux (alpha envs) seem to prevent writes.
+      - pocketbase-data:/pb_data
+      # To pick up migration data
       - ../pocketbase-migrations:/pb_migrations
 
   client:
@@ -15,3 +17,6 @@ services:
       - ./nginx/templates:/etc/nginx/templates
     environment:
       - API_BASE_URL=http://pocketbase:8090
+
+volumes:
+  pocketbase-data:


### PR DESCRIPTION
Linux machines seem to not allow mounting so we're switching to volumes for alpha setups instead.
