### PR TITLE
CI/CD #37: Expose only the `pocketbase/api` path, not the admin path (`pocketbase/_/`)

### DIFF
--- a/compose/alpha/nginx/templates/default.conf.template
+++ b/compose/alpha/nginx/templates/default.conf.template
@@ -15,10 +15,9 @@ server {
 
   charset utf-8;
 
-  # This is the prod equivalent of the Vite dev env reverse proxy
-  location /pocketbase/ {
+  location /pocketbase/api/ {
     # The trailing "/" is important. This won't work without it.
-    proxy_pass ${API_BASE_URL}/;
+    proxy_pass ${API_BASE_URL}/api/;
   }
 
   location / {


### PR DESCRIPTION
This is to reduce security risks